### PR TITLE
Modify loading of modules

### DIFF
--- a/mlproject/README.md
+++ b/mlproject/README.md
@@ -1,5 +1,9 @@
-### In juwelsbooster
-1. Set python to version 3.9. For this load the following modules:
+# Running Application 3 with Mantik CLI
+To run this application in juwels-booster with the mantik CLI follow these instructions:
+
+1. Login to juwels-booster via SSH. To access juwels-booster via SSH, please follow the instructions provided in this [tutorial](https://apps.fz-juelich.de/jsc/hps/juwels/access.html#ssh-login)
+
+2. Once you are logged in on juwels-booster, set python to version 3.9. For this load the following modules:
 ```
 ml --force purge
 ml use $OTHERSTAGES
@@ -8,25 +12,25 @@ ml GCCcore/.11.2.0
 ml Python/3.9.6
 ```
 
-2. Create a virtual enviroment and activate it:
+3. Create a virtual enviroment and activate it:
 ```
 python -m venv <venv-name>
 source <venv-name>/bin/activate
 ```
 
-3. Clone this Git repository and checkout the `main` branch
+4. Clone this Git repository and checkout the `main` branch
 
 ```
 git clone https://github.com/saragrau4/maelstrom-radiation.git
 git checkout main
 ```
 
-3. Install ap3 dependencies with pip. 
+5. Install ap3 dependencies with pip. 
 ```
 pip install -r requirements_wo_modules.txt
 ```
 
-4. Add the following code at the end of the virtual enviroment activate file `<venv-name>/bin/activate`:
+6. Add the following code at the end of the virtual enviroment activation file `<venv-name>/bin/activate`:
 ```
 BASE_DIR="<absolute path to maelstrom-radiation/climetlab_maelstrom_radiation/benchmarks directory>"
 # expand PYTHONPATH
@@ -39,13 +43,10 @@ export PYTHONPATH=${BASE_DIR}/postprocess:$PYTHONPATH
 export PYTHONPATH=${BASE_DIR}/preprocess:$PYTHONPATH
 
 ```
-### In mantik
 
-Set up a project in Mantik to enable the execution of your experiment. For a step-by-step guide, refer to the quickstart tutorial available [here](https://mantik-ai.gitlab.io/mantik/ui/quickstart.html)
+7. The results will be logged to an Experiment on the MLflow tracking server on Mantik. Set up a project in Mantik and create a new Experiment. Note its experiment Id, which will be needed in the submission command. For a step-by-step guide, refer to the Quickstart tutorial available [here](https://mantik-ai.gitlab.io/mantik/ui/quickstart.html).
 
-### In your local mlproject
-
-1. Set `PreRunCommand` in `unicore-config-venv.yaml` to the path of your virtual enviroment
+8. Update the `unicore-config-venv.yaml` file by specifying the `PreRunCommand` with the path to your virtual environment.
 
 <pre><code>   PreRunCommand:
     Command: > 
@@ -53,7 +54,7 @@ Set up a project in Mantik to enable the execution of your experiment. For a ste
       source <b>/path/to/&lt;venv-name&gt;</b>/bin/activate;
 </code></pre>
 
-2. Run your experiment with mantik
+9. Run your experiment with mantik
 ```
-mantik runs submit <absolute path to maelstrom-radiation/mlproject directory> --backend-config unicore-config-venv.yaml --entry-point main --experiment-id <experiment ID> -v
+mantik runs submit <absolute path to maelstrom-radiation/mlproject directory> --backend-config unicore-config-venv.yaml --entry-point main --experiment-id <experiment ID> --runb-name <run name> -v
 ```

--- a/mlproject/README.md
+++ b/mlproject/README.md
@@ -45,12 +45,13 @@ Set up a project in Mantik to enable the execution of your experiment. For a ste
 
 ### In your local mlproject
 
-1. Set `Python` in `unicore-config-venv.yaml` to the path of your virtual enviroment
+1. Set `PreRunCommand` in `unicore-config-venv.yaml` to the path of your virtual enviroment
 
-```
-Environment:
-  Python: /path/to/<venv-name>
-```
+<pre><code>   PreRunCommand:
+    Command: > 
+      module load Stages/2022 GCCcore/.11.2.0 GCC/11.2.0 cuDNN/8.3.1.22-CUDA-11.5 Python/3.9.6
+      source <b>/path/to/&lt;venv-name&gt;</b>/bin/activate;
+</code></pre>
 
 2. Run your experiment with mantik
 ```

--- a/mlproject/unicore-config-venv.yaml
+++ b/mlproject/unicore-config-venv.yaml
@@ -1,12 +1,10 @@
 UnicoreApiUrl: https://zam2125.zam.kfa-juelich.de:9112/JUWELS/rest/core
 Environment:
-  Python: /p/project/deepacf/maelstrom/grau1/ap3_env
-  Modules:
-    - Stages/2022
-    - GCCcore/.11.2.0
-    - GCC/11.2.0
-    - cuDNN/8.3.1.22-CUDA-11.5
-    - Python/3.9.6
+  PreRunCommand:
+    Command: > 
+      module load Stages/2022 GCCcore/.11.2.0 GCC/11.2.0 cuDNN/8.3.1.22-CUDA-11.5 Python/3.9.6;
+      source /p/project/deepacf/maelstrom/grau1/ap3_env/bin/activate;
+    ExecuteOnLoginNode: False
   Variables:
     GIT_PYTHON_REFRESH: quiet
 Resources:

--- a/requirements_wo_modules.txt
+++ b/requirements_wo_modules.txt
@@ -2,5 +2,7 @@ tensorflow==2.6.0
 mlflow==2.2.2
 protobuf==3.20.1
 keras==2.6
+climetlab==0.16.1
+psutil
 -e .
 


### PR DESCRIPTION
Findings
- Apparently the modules don't vanish when loading them before the activation of the virtual environment
- Also the modules Stages/2022 and Python/3.9.6 should never be loaded after venv activation. If this is done, the local Python will be used instead of the one in the venv causing the system to search within the local Python's site-packages directory instead of the venv's Python's site-packages directory.

For these reasons the backend-config was changed